### PR TITLE
fixing a conflict with resolutions in Dekker tad calling module

### DIFF
--- a/hic-16.05/hic.sh
+++ b/hic-16.05/hic.sh
@@ -769,7 +769,7 @@ dekker_call() {
 
 	# call TADs with the Dekker method
 	message_info $step "call TADs using Dekker's method"
-	resolution_nice=`$python $SCRIPTS/nice.py $resolution_ab`
+	resolution_nice=`$python $SCRIPTS/nice.py $resolution_tad`
 	MY_TMP=$DOWNSTREAM/my_tmp 
 	mkdir -p $MY_TMP
 	$SCRIPTS/dekker_call.r $DOWNSTREAM/${sample_id}_normalized_${resolution_nice}.tsv.gz $ibam $resolution_tad $slots $DOWNSTREAM/${sample_id} $pis $pids $pnt $MY_TMP &>>$step_log


### PR DESCRIPTION
In Dekker TAD calling module the resolution was not properly set: It was fetching the data with AB resolution (100 kb) but requesting the computation to be don at TAD resolution (50 kb) resulting in a insulation index with a  strange pattern.

Dekker TADs module should be re-run for all processed samples.
![dekker_resolution_conflict](https://cloud.githubusercontent.com/assets/3636270/25696432/776137f6-30b7-11e7-96f9-24bb7853a480.png)
